### PR TITLE
fix/after-v1

### DIFF
--- a/middlewares/middlewares.go
+++ b/middlewares/middlewares.go
@@ -38,7 +38,7 @@ func AuthorizeMiddleware(next http.Handler) http.Handler {
 		if err := dynamo.Setup(); err != nil {
 			log.Fatal(err)
 		}
-		headerApiKey := r.Header.Get("api-key")
+		headerApiKey := r.Header.Get("c-token")
 		if headerApiKey != "" {
 			client, err := dynamo.GetClientByApiKey(headerApiKey)
 			if err != nil {
@@ -69,7 +69,7 @@ func AuthorizeMiddlewareByServiceApiKey(next http.Handler) http.Handler {
 		if err := dynamo.Setup(); err != nil {
 			log.Fatal(err)
 		}
-		headerApiKey := r.Header.Get("api-key")
+		headerApiKey := r.Header.Get("s-token")
 		if headerApiKey != "" {
 			_, err := dynamo.GetServiceByApiKey(headerApiKey)
 			if err != nil {
@@ -94,7 +94,7 @@ func AuthorizeMiddlewareByServiceApiKey(next http.Handler) http.Handler {
 func AuthorizeAdminMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := utils.NewLogger(os.Stdout)
-		headerApiKey := r.Header.Get("api-key")
+		headerApiKey := r.Header.Get("a-token")
 		strBase64 := os.Getenv("ADMIN_APIS_KEY")
 		adminApisKeysJson, err := base64.StdEncoding.DecodeString(strBase64)
 

--- a/tests/dynamodb_test.go
+++ b/tests/dynamodb_test.go
@@ -96,7 +96,7 @@ func TestDeleteSubscriptions(t *testing.T) {
 	if err := dynamo.Setup(); err != nil {
 		t.Errorf("TestDeleteSubscriptions: expect(nil) - got(%s)\n", err.Error())
 	}
-	if err := dynamo.DeleteSubscription("id@tom", "batch-item.pix.paid"); err != nil {
+	if err := dynamo.DeleteSubscription("id@tom", "batch-item.pix.paid", "google.com"); err != nil {
 		t.Errorf("TestDeleteSubscriptions: expect(nil) - got(%s)\n", err.Error())
 	}
 }


### PR DESCRIPTION
- Mudou os tokens de autenticação:
	- Para client: c-token;
	- Para service: s-token;
	- Para admin: a-token;
- Adicionado novas verificações:
	- Criada mais de uma subcription por evento;
	- Verificar se o service existe na criação da subscription;
	- Verifica se o client está inserido no service do event;